### PR TITLE
Stop using deprecated Manifest.writeTo(Writer) and using Manifest.wri…

### DIFF
--- a/src/main/groovy/com/github/rholder/gradle/task/OneJar.groovy
+++ b/src/main/groovy/com/github/rholder/gradle/task/OneJar.groovy
@@ -178,14 +178,13 @@ class OneJar extends Jar {
     File writeOneJarManifestFile(Manifest manifest) {
         File manifestFile = File.createTempFile("one-jar-manifest", ".mf")
         manifestFile.deleteOnExit()
+        
+        manifest.attributes.put("Main-Class", "com.simontuffs.onejar.Boot")
+        manifest.attributes.put("One-Jar-Main-Class", mainClass)
+        manifest.attributes.put("One-Jar-Show-Expand", showExpand)
+        manifest.attributes.put("One-Jar-Confirm-Expand", confirmExpand)
+        manifest.writeTo(manifestFile.path)
 
-        manifestFile.withWriter { writer ->
-            manifest.attributes.put("Main-Class", "com.simontuffs.onejar.Boot")
-            manifest.attributes.put("One-Jar-Main-Class", mainClass)
-            manifest.attributes.put("One-Jar-Show-Expand", showExpand)
-            manifest.attributes.put("One-Jar-Confirm-Expand", confirmExpand)
-            manifest.writeTo(writer)
-        }
-        return manifestFile
+        manifestFile
     }
 }


### PR DESCRIPTION
…teTo(Object) instead

In Gradle 4.0 Manifest.writeTo(Writer) will be removed, to make it compatible, Manifest.writeTo(Object) needs to be used