### PR TITLE
Remove redundant output declaration

### DIFF
--- a/src/main/groovy/com/github/rholder/gradle/task/OneJar.groovy
+++ b/src/main/groovy/com/github/rholder/gradle/task/OneJar.groovy
@@ -70,7 +70,6 @@ class OneJar extends Jar {
         dependsOn = [baseJar]
 
         inputs.files([baseJar.getArchivePath().absoluteFile])
-        outputs.file(new File(baseJar.getArchivePath().parentFile.absolutePath, getArchiveName()))
 
         doFirst {
             if (!mainClass) {


### PR DESCRIPTION
Since OneJar extends standard Jar task, it already inherits desired output.

Repeating declaration leads to inappropriate behavior of OneJar tasks:

```groovy
task oneJar(type: OneJar) {
    mainClass = 'com.github.rholder.awesome.MyAwesomeMain'
}

task onejar_test() {
    println(onejar.outputs.files.files.size()) // 2
    println(onejar.outputs.files.files) //%buildDir%/libs/standalone.jar
                                        //%buildDir%/libs/[archiveBaseName]-[archiveAppendix]-[archiveVersion]-standalone.jar
    println(onejar.outputs.files.singleFile) //Fails with error "Expected task 'onejar' output files to contain exactly one file, however, it contains more than one file."
}
```

This create obstacles when onejar tasks are composed into pipeline and some other tasks are taking its outputs as an input.
